### PR TITLE
Fix a shifted row on the supported features page

### DIFF
--- a/supported-features.html
+++ b/supported-features.html
@@ -1583,7 +1583,8 @@
 <td style="text-align:center">&#x1F44D;</td>
 </tr>
 <tr>
-<td style="text-align:left">Range selector (Ease Low)       &#x26D4;</td>
+<td style="text-align:left">Range selector (Ease Low)</td>
+<td style="text-align:center">&#x26D4;&#xFE0F;</td>
 <td style="text-align:center">&#x26D4;&#xFE0F;</td>
 <td style="text-align:center">&#x1F44D;</td>
 <td style="text-align:center">&#x1F44D;</td>


### PR DESCRIPTION
I've spotted a table row gone wild and fixed it.


![screenshhot](https://user-images.githubusercontent.com/6809803/33313253-327274ac-d43b-11e7-88c0-9244011ed8dc.png)
